### PR TITLE
Fix OpenClaw Docker setup startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,15 @@ cd openclaw-in-docker
 Default:
 
 ```bash
-export OPENCLAW_IMAGE="alpine/openclaw:latest"
+export OPENCLAW_IMAGE="alpine/openclaw:main"
 ```
 
-> Note: recently, `latest` has had issues for some users, no models you can choice.
-> If you hit problems, switch to:
+> Note: `main` is the setup script default because it currently avoids issues
+> some users have seen with `latest`.
+> If you prefer the release tag, switch to:
 
 ```bash
-export OPENCLAW_IMAGE="alpine/openclaw:main"
+export OPENCLAW_IMAGE="alpine/openclaw:latest"
 ```
 
 ## 3) Run the setup script
@@ -44,9 +45,15 @@ export OPENCLAW_IMAGE="alpine/openclaw:main"
 This script will:
 
 * pull openclaw gateway image
-* Launch an onboarding wizard
+* Create baseline OpenClaw config non-interactively
 * Start the gateway via Docker Compose
 * Generate a gateway token and store it in .env
+
+After the gateway is running, you can run the interactive onboarding wizard:
+
+```bash
+docker compose run --rm openclaw-cli onboard --no-install-daemon
+```
 ---
 
 ### 4) Upgrade OpenClaw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@ services:
       HOME: /home/node
       TERM: xterm-256color
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN}
-      CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
-      CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
-      CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
+      CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY:-}
+      CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY:-}
+      CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE:-}
     volumes:
       - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
       - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
@@ -21,10 +21,16 @@ services:
         "node",
         "dist/index.js",
         "gateway",
+        "run",
         "--bind",
         "${OPENCLAW_GATEWAY_BIND:-lan}",
+        "--auth",
+        "token",
+        "--token",
+        "${OPENCLAW_GATEWAY_TOKEN}",
         "--port",
         "18789",
+        "--allow-unconfigured",
       ]
 
   openclaw-cli:
@@ -34,9 +40,9 @@ services:
       TERM: xterm-256color
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN}
       BROWSER: echo
-      CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
-      CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
-      CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
+      CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY:-}
+      CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY:-}
+      CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE:-}
     volumes:
       - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
       - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 EXTRA_COMPOSE_FILE="$ROOT_DIR/docker-compose.extra.yml"
-IMAGE_NAME="${OPENCLAW_IMAGE:-openclaw:local}"
+IMAGE_NAME="${OPENCLAW_IMAGE:-alpine/openclaw:main}"
 EXTRA_MOUNTS="${OPENCLAW_EXTRA_MOUNTS:-}"
 HOME_VOLUME_NAME="${OPENCLAW_HOME_VOLUME:-}"
 
@@ -184,18 +184,31 @@ upsert_env "$ENV_FILE" \
 #   "$ROOT_DIR"
 
 echo ""
-echo "==> Onboarding (interactive)"
-echo "When prompted:"
-echo "  - Gateway bind: lan"
-echo "  - Gateway auth: token"
-echo "  - Gateway token: $OPENCLAW_GATEWAY_TOKEN"
-echo "  - Tailscale exposure: Off"
-echo "  - Install Gateway daemon: No"
+echo "==> Pulling Docker image: $IMAGE_NAME"
+docker pull "$IMAGE_NAME"
+
 echo ""
-docker compose "${COMPOSE_ARGS[@]}" run --rm openclaw-cli onboard --no-install-daemon
+echo "==> Creating baseline OpenClaw config"
+docker compose "${COMPOSE_ARGS[@]}" run --rm openclaw-cli onboard \
+  --non-interactive \
+  --accept-risk \
+  --mode local \
+  --auth-choice skip \
+  --gateway-bind "$OPENCLAW_GATEWAY_BIND" \
+  --gateway-auth token \
+  --gateway-token "$OPENCLAW_GATEWAY_TOKEN" \
+  --tailscale off \
+  --no-install-daemon \
+  --skip-health \
+  --skip-channels \
+  --skip-ui \
+  --skip-skills \
+  --workspace /home/node/.openclaw/workspace
 
 echo ""
 echo "==> Provider setup (optional)"
+echo "Interactive onboarding:"
+echo "  ${COMPOSE_HINT} run --rm openclaw-cli onboard --no-install-daemon"
 echo "WhatsApp (QR):"
 echo "  ${COMPOSE_HINT} run --rm openclaw-cli channels login"
 echo "Telegram (bot token):"


### PR DESCRIPTION
## What changed
- Default the setup script to the published alpine/openclaw:main image instead of a missing local image.
- Run non-interactive onboarding with gateway token settings so the script can complete without manual prompts.
- Start the gateway with the explicit gateway run subcommand and token auth.
- Silence optional Claude environment variable warnings and update the README setup notes.

## Why
The previous script could try to run openclaw:local even though this repo does not build that image, then get stuck in interactive onboarding before starting the gateway.

## Tested
- bash docker-setup.sh
- docker compose ps
- docker compose logs --tail 80 openclaw-gateway
- docker compose exec -T openclaw-gateway node dist/index.js health --token <token>
- docker compose config --quiet